### PR TITLE
Add middleware group register method and it's test #7

### DIFF
--- a/app.go
+++ b/app.go
@@ -49,7 +49,7 @@ func AppFromContext(ctx Context) *App {
 
 // GetGroup get a middlware group
 func (app *App) GetRouteGroup(prefix string) *echo.Group {
-	g := app.Echo.Group(prefix)
+	g := app.Group(prefix)
 	if app.MiddlewareGroup == nil {
 		return g
 	}

--- a/app.go
+++ b/app.go
@@ -8,9 +8,13 @@ import (
 type App struct {
 	*echo.Echo
 
-	Logger   *Logger
-	Services *Container
+	Logger          *Logger
+	Services        *Container
+	MiddlewareGroup MiddlewareGroup
 }
+
+// MiddlewareGroup string key is the route prefix, value is []MiddlewareFunc
+type MiddlewareGroup = map[string][]MiddlewareFunc
 
 // AppContext is wrapper of echo.Context. It holds App instance of server.
 type AppContext struct {
@@ -41,4 +45,29 @@ func AppFromContext(ctx Context) *App {
 		return nil
 	}
 	return ac.App()
+}
+
+// GetGroup get a middlware group
+func (app *App) GetRouteGroup(prefix string) *echo.Group {
+	g := app.Echo.Group(prefix)
+	if app.MiddlewareGroup == nil {
+		return g
+	}
+
+	middlewares, ok := app.MiddlewareGroup[prefix]
+	if !ok {
+		return g
+	}
+
+	g.Use(middlewares...)
+
+	return g
+}
+
+func (app *App) AddMiddlewareGroup(prefix string, m []MiddlewareFunc) {
+	if app.MiddlewareGroup == nil {
+		app.MiddlewareGroup = MiddlewareGroup{}
+	}
+
+	app.MiddlewareGroup[prefix] = m
 }

--- a/app_test.go
+++ b/app_test.go
@@ -3,6 +3,7 @@ package gopress
 import (
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/labstack/echo"
@@ -33,5 +34,25 @@ func TestAppContextMiddleware(t *testing.T) {
 
 	if c, ok := actual.(*AppContext); !ok {
 		t.Errorf("expect context is AppContext, actual is %#v", c)
+	}
+}
+
+func TestAppAddMiddlewareGroup(t *testing.T) {
+	app := &App{}
+	m := make([]MiddlewareFunc, 0)
+	m = append(m, NewLoggingMiddleware("global", NewLogger()))
+	app.AddMiddlewareGroup("/hello", m)
+	m2, ok := app.MiddlewareGroup["/hello"]
+	if !ok {
+		t.Errorf("expect prefix:/hello's middlewarefunc exists, but not")
+	}
+
+	if len(m2) != 1 {
+
+		t.Errorf("expect middlewaregroup len is 1, got %d", len(m2))
+	}
+
+	if reflect.TypeOf(m2[0]).String() != reflect.TypeOf(m[0]).String() {
+		t.Errorf("expect type  []middlewareFunc, got %s", reflect.TypeOf(m2).String())
 	}
 }

--- a/app_test.go
+++ b/app_test.go
@@ -39,6 +39,8 @@ func TestAppContextMiddleware(t *testing.T) {
 
 func TestAppAddMiddlewareGroup(t *testing.T) {
 	app := &App{}
+	app.Echo = echo.New()
+
 	m := make([]MiddlewareFunc, 0)
 	m = append(m, NewLoggingMiddleware("global", NewLogger()))
 	app.AddMiddlewareGroup("/hello", m)
@@ -54,5 +56,10 @@ func TestAppAddMiddlewareGroup(t *testing.T) {
 
 	if reflect.TypeOf(m2[0]).String() != reflect.TypeOf(m[0]).String() {
 		t.Errorf("expect type  []middlewareFunc, got %s", reflect.TypeOf(m2).String())
+	}
+
+	g := app.GetRouteGroup("/hello")
+	if reflect.TypeOf(g).String() != reflect.TypeOf(&echo.Group{}).String() {
+		t.Errorf("expect group's type is *echo.Group, got %v", g)
 	}
 }

--- a/app_test.go
+++ b/app_test.go
@@ -40,6 +40,10 @@ func TestAppContextMiddleware(t *testing.T) {
 func TestAppAddMiddlewareGroup(t *testing.T) {
 	app := &App{}
 	app.Echo = echo.New()
+	g1 := app.GetRouteGroup("/hello")
+	if g1 == nil {
+		t.Errorf("get no middleware group failed")
+	}
 
 	m := make([]MiddlewareFunc, 0)
 	m = append(m, NewLoggingMiddleware("global", NewLogger()))
@@ -50,7 +54,6 @@ func TestAppAddMiddlewareGroup(t *testing.T) {
 	}
 
 	if len(m2) != 1 {
-
 		t.Errorf("expect middlewaregroup len is 1, got %d", len(m2))
 	}
 
@@ -61,5 +64,10 @@ func TestAppAddMiddlewareGroup(t *testing.T) {
 	g := app.GetRouteGroup("/hello")
 	if reflect.TypeOf(g).String() != reflect.TypeOf(&echo.Group{}).String() {
 		t.Errorf("expect group's type is *echo.Group, got %v", g)
+	}
+
+	_, ok = app.MiddlewareGroup["/notwell"]
+	if ok {
+		t.Errorf("expect no /notwell group, but it's exists ")
 	}
 }


### PR DESCRIPTION
```go
// main.go or other  file register the middleware group
app.AddMiddlewareGroup("/user", []MiddlewareFunc{ m1, m2, ...})

// Usage in controllers
RegisterRoute(app *gopress.App) {
       g := app.GetGroup("/user")
       g.GET("/:id", handleFunc)
}
```